### PR TITLE
Intelsat

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ansible RKE2 (RKE Government) Playbook
 ---------
 [![LINT](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ci.yml/badge.svg)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ci.yml)
 
-RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution. This Ansible  playbook installs RKE2 for both the control plane and workers.
+RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution. This Ansible playbook installs RKE2 for both the control plane and workers.
 
 See the [docs](https://docs.rke2.io/) more information about [RKE Government](https://docs.rke2.io/).
 

--- a/roles/rke2_agent/defaults/main.yml
+++ b/roles/rke2_agent/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 kubernetes_api_server_host: "{{ hostvars[groups['rke2_servers'][0]].inventory_hostname }}"
+mounts: []

--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -7,6 +7,10 @@
     name: rke2_common
     tasks_from: main
 
+- name: Include mount tasks
+  include_tasks: mounts.yml
+  when: agent_mounts | length > 0
+
 - name: Does config file already have server token?  # noqa command-instead-of-shell
   command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'
   register: server_token_check

--- a/roles/rke2_agent/tasks/main.yml
+++ b/roles/rke2_agent/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Include mount tasks
   include_tasks: mounts.yml
-  when: agent_mounts | length > 0
+  when: mounts | length > 0
 
 - name: Does config file already have server token?  # noqa command-instead-of-shell
   command: 'grep -i "^token:" /etc/rancher/rke2/config.yaml'

--- a/roles/rke2_agent/tasks/mounts.yml
+++ b/roles/rke2_agent/tasks/mounts.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Set up mount points for additional disks
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: "{{ item.fstype }}"
+    state: present
+  with_items:
+    - "{{ mounts }}"

--- a/roles/rke2_common/defaults/main.yml
+++ b/roles/rke2_common/defaults/main.yml
@@ -21,3 +21,5 @@ rke2_versioned_yum_repo:
   enabled: yes
 
 rke2_config: {}
+
+mounts: []

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -55,6 +55,21 @@
     - ansible_facts.services["firewalld.service"] is defined
     - ansible_facts.services["firewalld.service"].status != "not-found"
 
+- name: Disable swap
+  ansible.builtin.command: swapoff -a
+  when: not installed
+
+- name: Disable swap in fstab
+  replace:
+    path: /etc/fstab
+    regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
+    replace: '# \1'
+  when: not installed
+
+- name: Include mount tasks
+  include_tasks: mounts.yml
+  when: cluster_mounts | length > 0
+
 - name: Include task file network_manager_fix.yaml
   include_tasks: network_manager_fix.yaml
 

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -68,7 +68,7 @@
 
 - name: Include mount tasks
   include_tasks: mounts.yml
-  when: cluster_mounts | length > 0
+  when: mounts | length > 0
 
 - name: Include task file network_manager_fix.yaml
   include_tasks: network_manager_fix.yaml

--- a/roles/rke2_common/tasks/mounts.yml
+++ b/roles/rke2_common/tasks/mounts.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Set up mount points for additional disks
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: "{{ item.fstype }}"
+    state: present
+  with_items:
+    - "{{ mounts }}"

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -23,7 +23,6 @@
     changed_when: false
     args:
       executable: /usr/bin/bash
-    ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set rke2_full_version fact  # noqa var-spacing
   set_fact:

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -12,6 +12,9 @@
     uri:
       url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
       follow_redirects: all
+    environment:
+      - http_proxy: "{{ http_proxy | default(omit) }}"
+      - https_proxy: "{{ https_proxy | default(omit) }}"
     register: rke2_version_url
 
   - name: Set full version name

--- a/roles/rke2_common/tasks/rpm_install.yml
+++ b/roles/rke2_common/tasks/rpm_install.yml
@@ -23,6 +23,7 @@
     changed_when: false
     args:
       executable: /usr/bin/bash
+    ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set rke2_full_version fact  # noqa var-spacing
   set_fact:

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -51,6 +51,7 @@
       changed_when: false
       args:
         executable: /bin/bash
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Set dot version
       shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -51,7 +51,6 @@
       changed_when: false
       args:
         executable: /bin/bash
-      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Set dot version
       shell: set -o pipefail && echo {{ rke2_full_version.stdout }} | /usr/bin/cut -d'+' -f1

--- a/roles/rke2_common/tasks/tarball_install.yml
+++ b/roles/rke2_common/tasks/tarball_install.yml
@@ -40,6 +40,9 @@
       uri:
         url: https://update.rke2.io/v1-release/channels/{{ rke2_channel }}
         follow_redirects: all
+      environment:
+        - http_proxy: "{{ http_proxy | default(omit) }}"
+        - https_proxy: "{{ https_proxy | default(omit) }}"
       register: rke2_version_url
 
     - name: Set full version name

--- a/roles/rke2_server/defaults/main.yml
+++ b/roles/rke2_server/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 kubernetes_api_server_host: "{{ hostvars[groups['rke2_servers'][0]].inventory_hostname }}"
+mounts: []

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -7,6 +7,10 @@
     name: rke2_common
     tasks_from: main
 
+- name: Include mount tasks
+  include_tasks: mounts.yml
+  when: server_mounts | length > 0
+
 - name: Setup initial server
   include_tasks: first_server.yml
   when: inventory_hostname in groups['rke2_servers'][0]

--- a/roles/rke2_server/tasks/main.yml
+++ b/roles/rke2_server/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Include mount tasks
   include_tasks: mounts.yml
-  when: server_mounts | length > 0
+  when: mounts | length > 0
 
 - name: Setup initial server
   include_tasks: first_server.yml

--- a/roles/rke2_server/tasks/mounts.yml
+++ b/roles/rke2_server/tasks/mounts.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Set up mount points for additional disks
+  ansible.posix.mount:
+    src: "{{ item.src }}"
+    path: "{{ item.path }}"
+    fstype: "{{ item.fstype }}"
+    state: present
+  with_items:
+    - "{{ mounts }}"


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

This is a request to merge in changes made to run this in the Intelsat lab environment. The environment is not air-gapped, but behind an http proxy, which required some environment variables to be set in the URI calls. Turning off swap and ensuring required mounts are in place were both required for the installs, but only swap is directly related to a Kubernetes requirement.

## Which issue(s) this PR fixes:

NA

## Testing

This branch was directly used to deploy two clusters, a 3-node server-only cluster for Rancher MCM and a 3-server, 3-worker common tools cluster imported into Rancher after provisioning via Ansible.

## Release Notes

* Turns off swap and comments out any swap automounting in `/etc/fstab`
* Adds ability to run playbook behind an http proxy
* Adds ability to ensure mount points required for Kubernetes installation are present before rke2 is installed

```release-note

```

