### PR TITLE
Add Galaxy collection workflow, badge, and metadata

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,0 +1,58 @@
+name: Galaxy Collection
+
+on:
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    name: Validate Galaxy collection metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible
+        run: python -m pip install --upgrade pip ansible
+
+      - name: Build Ansible collection
+        run: ansible-galaxy collection build --force
+
+      - name: Verify built collection archive
+        run: |
+          ls -1 *.tar.gz
+          ansible-galaxy collection install --force *.tar.gz
+
+  publish:
+    name: Publish Galaxy collection
+    needs: validate
+    runs-on: ubuntu-latest
+    if: "github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'v')"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible
+        run: python -m pip install --upgrade pip ansible
+
+      - name: Build collection artifact
+        run: ansible-galaxy collection build --force
+
+      - name: Publish collection to Ansible Galaxy
+        run: ansible-galaxy collection publish --api-key "${{ secrets.ANSIBLE_GALAXY_API_KEY }}" *.tar.gz

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See the [docs](https://docs.rke2.io/) more information about [RKE Government](ht
 Platforms
 ---------  
 
-[![Lint](https://github.com/rancherfederal/rke2-ansible/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/lint.yml) [![Rocky](https://github.com/rancherfederal/rke2-ansible/actions/workflows/rocky.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/rocky.yml) [![Ubuntu](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ubuntu.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ubuntu.yml)
+[![Lint](https://github.com/rancherfederal/rke2-ansible/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/lint.yml) [![Rocky](https://github.com/rancherfederal/rke2-ansible/actions/workflows/rocky.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/rocky.yml) [![Ubuntu](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ubuntu.yml/badge.svg?branch=main)](https://github.com/rancherfederal/rke2-ansible/actions/workflows/ubuntu.yml) [![Ansible Galaxy](https://img.shields.io/badge/Ansible%20Galaxy-rancherfederal.rke2_ansible-blue?logo=ansible&style=flat-square)](https://galaxy.ansible.com/rancherfederal/rke2_ansible)
 
 The RKE2 Ansible playbook supports:
 - Rocky 8, and 9


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

Add Ansible Galaxy publishing support for rke2-ansible.

### What changed
- Added `.github/workflows/galaxy.yml`
  - Builds the collection
  - Validates the generated `.tar.gz`
  - Publishes to Ansible Galaxy on tagged releases using `ANSIBLE_GALAXY_API_KEY`
- Updated README.md
  - Added an Ansible Galaxy badge

### Notes
- `meta/runtime.yml` remains in place for runtime compatibility metadata.
- The workflow is triggered on `push` tags matching `v*` and also supports manual dispatch.

## Which issue(s) this PR fixes:

Fixes #273

## Special notes for your reviewer:

Please ensure that the `ANSIBLE_GALAXY_API_KEY` secret is configured.

Once it's in place, please release a new version and verify that the release has been successfully published to Ansible Galaxy.

## Release Notes

```release-note
Added GitHub Actions workflow to build and publish the rke2_ansible collection to Ansible Galaxy; CI now validates PRs and publishes on GitHub Releases.
```

