### PR TITLE
fix: guard node_metrics.status against skipped uri task in check mode

### DIFF
--- a/roles/rke2/tasks/check_node_ready.yml
+++ b/roles/rke2/tasks/check_node_ready.yml
@@ -36,6 +36,7 @@
   ansible.builtin.set_fact:
     rke2_metrics_running: true
   when:
+    - node_metrics.status is defined
     - 200 | string in node_metrics.status | string
   tags: ["configure"]
 
@@ -43,6 +44,7 @@
   ansible.builtin.set_fact:
     kubelet_node_name: "{{ node_metrics.content | regex_search('kubelet_node_name{node=\"(.*)\"}', '\\1') }}"
   when:
+    - node_metrics.status is defined
     - 200 | string in node_metrics.status | string
   tags: ["configure"]
 


### PR DESCRIPTION
## What type of PR is this?

  - [x] bug
  
## What this PR does / why we need it:

Performing a dry-run with `--check` fails on all of my nodes:

```
  fatal: [host]: FAILED! => {
    "msg": "The conditional check '200 | string in node_metrics.status | string'
    failed. 'dict object' has no attribute 'status'
    ...check_node_ready.yml: line 35, column 3...
    - name: Check that node_metrics collection was successful
      ^ here"
  }
```
The fix:

Only check node_metrics.status if it is actually defined. During dry-runs with `--check`, it won't be defined & should be skipped. But when we're running on live servers, node_metrics.status should exist and the code will continue as expected.

Related:

In commit 5165e3e, someone else tried to fix this with a broader change: `ignore_errors: "{{ ansible_check_mode }}"`. This change is narrower.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## Which issue(s) this PR fixes:

No issue filed (issues are redirected to the support portal).

## Special notes for your reviewer:

Only one file changed: `check_node_ready.yml`. 2 lines.

## Testing

I found this while testing v2.1.0 branch against a test cluster here:

v1.32.6+rke2r1, Ubuntu 22.04, 3 control plane nodes

## Release Notes

Fix crash when running in `--check` mode due to skipped uri task

# Note:

Found this bug with the help of Claude Sonnet 4.6