### PR TITLE
updating external configs to be templates

### DIFF
--- a/roles/rke2/defaults/main.yml
+++ b/roles/rke2/defaults/main.yml
@@ -72,13 +72,13 @@ host_rke2_config: {}
 ## API Address for Cluster if behind Loadbalancer or Virtual IP.
 rke2_kubernetes_api_server_host: ""
 
-## Path, local to Ansible control host, where audit policy can be found.
+## Path, local to Ansible control host, where audit policy can be found. File can be a template.
 rke2_audit_policy_config_file_path: ""
 
-## Path, local to Ansible control host, where registries config can be found.
+## Path, local to Ansible control host, where registries config can be found. File can be a template.
 rke2_registry_config_file_path: ""
 
-## Path, local to Ansible control host, where PSA policy can be found.
+## Path, local to Ansible control host, where PSA policy can be found. File can be a template.
 rke2_pod_security_admission_config_file_path: ""
 
 ## Set 'true' if Ansible should automatically add IPTABLES rules to allow for Kubernetes traffic.
@@ -90,10 +90,10 @@ rke2_manifest_config_directory: ""
 ## Path, local to Ansible control host, where manifests can be found that will be added (to server/manifests directory) and automatically applied after last server is up.
 rke2_manifest_config_post_run_directory: ""
 
-## Path, local to Ansible control host, where systemd environment file config can be found (Proxy Config).
+## Path, local to Ansible control host, where systemd environment file config can be found (Proxy Config). File can be a template.
 rke2_systemd_env_config_file_path: ""
 
-## Path, local to Ansible control host, where kube-api-authn-webhook.yaml config can be found (ACE Config).
+## Path, local to Ansible control host, where kube-api-authn-webhook.yaml config (or template) can be found (ACE Config).
 ### Warning: You must also set:
 ### rke2_config:
 ###    kube-apiserver-arg:

--- a/roles/rke2/tasks/configure_rke2.yml
+++ b/roles/rke2/tasks/configure_rke2.yml
@@ -13,7 +13,7 @@
 - name: Include task file add-systemd-env.yml
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
-    file_contents: "{{ lookup('file', rke2_systemd_env_config_file_path) }}"
+    file_contents: "{{ lookup('template', rke2_systemd_env_config_file_path) }}"
     file_destination: "/etc/default/{{ service_name }}"
     file_description: "systemd env options"
     file_path: "{{ rke2_systemd_env_config_file_path }}"
@@ -21,7 +21,7 @@
 - name: "Include task file add_ansible_managed_config.yml for {{ file_description }}"
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
-    file_contents: "{{ lookup('file', rke2_registry_config_file_path) }}"
+    file_contents: "{{ lookup('template', rke2_registry_config_file_path) }}"
     file_destination: "/etc/rancher/rke2/registries.yaml"
     file_description: "registry configuration"
     file_path: "{{ rke2_registry_config_file_path }}"
@@ -29,7 +29,7 @@
 - name: "Include task file add_ansible_managed_config.yml for {{ file_description }}"
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
-    file_contents: "{{ lookup('file', rke2_audit_policy_config_file_path) }}"
+    file_contents: "{{ lookup('template', rke2_audit_policy_config_file_path) }}"
     file_destination: "/etc/rancher/rke2/audit-policy.yaml"
     file_description: "audit policy configuration"
     file_path: "{{ rke2_audit_policy_config_file_path }}"
@@ -39,7 +39,7 @@
 - name: "Include task file add_ansible_managed_config.yml for {{ file_description }}"
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
-    file_contents: "{{ lookup('file', rke2_pod_security_admission_config_file_path) }}"
+    file_contents: "{{ lookup('template', rke2_pod_security_admission_config_file_path) }}"
     file_destination: "/etc/rancher/rke2/rke2-pss.yaml"
     file_description: "pod security admission config"
     file_path: "{{ rke2_pod_security_admission_config_file_path }}"
@@ -49,7 +49,7 @@
 - name: "Include task file add_ansible_managed_config.yml for {{ file_description }}"
   ansible.builtin.include_tasks: add_ansible_managed_config.yml
   vars:
-    file_contents: "{{ lookup('file', kube_api_authn_webhook_file_path) }}"
+    file_contents: "{{ lookup('template', kube_api_authn_webhook_file_path) }}"
     file_destination: "{{ rke2_data_dir }}kube-api-authn-webhook.yaml"
     file_description: "authorized cluster endpoint config"
     file_path: "{{ kube_api_authn_webhook_file_path }}"


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- [ ] bug
- [ ] cleanup
- [ ] documentation
- [x] feature

## What this PR does / why we need it:

_(REQUIRED)_

Switches `rke2_systemd_env_config_file_path`, `rke2_registry_config_file_path`, `rke2_audit_policy_config_file_path`, `rke2_pod_security_admission_config_file_path`, and `kube_api_authn_webhook_file_path` to be sourced as templates, allowing variables to be parsed.

## Which issue(s) this PR fixes:

Fixes #353 

## Release Notes

```release-note
Switches `rke2_systemd_env_config_file_path`, `rke2_registry_config_file_path`, `rke2_audit_policy_config_file_path`, `rke2_pod_security_admission_config_file_path`, and `kube_api_authn_webhook_file_path` to be sourced as templates, allowing variables to be parsed.
```

