### PR TITLE
Adding SLE Micro 6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The RKE2 Ansible playbook supports:
 - Rocky 8, and 9
 - RedHat: 8, and 9
 - Ubuntu: 22, and 24
+- SLE Micro 6 (experimental, see caveat below)
+
+> [!WARNING]  
+> Support for SLE Micro 6 is experimental. The SELinux profile is not activated/enforced on this platform.
 
 
 System requirements

--- a/roles/rke2/tasks/pre_reqs.yml
+++ b/roles/rke2/tasks/pre_reqs.yml
@@ -43,3 +43,47 @@
       allow perm=any all : dir=/var/lib/kubelet/
   notify: Restart fapolicyd
   tags: ["setup-os"]
+
+# Kubernetes/RKE2 requires swap disabled, the overlay/br_netfilter kernel
+# modules loaded, and bridged-traffic sysctls enabled. Rocky/RHEL/Ubuntu cloud
+# images already satisfy this; SUSE (e.g. SLE Micro) does not, so this is
+# scoped to that OS family only to avoid changing behavior for other users.
+- name: SUSE-specific kernel/network prerequisites
+  when: ansible_facts['os_family'] == 'Suse'
+  tags: ["setup-os"]
+  block:
+    - name: Disable swap for the current session
+      ansible.builtin.command: swapoff -a
+      when: ansible_facts.swaptotal_mb | default(0) > 0
+      changed_when: true
+
+    - name: Disable swap entries in /etc/fstab
+      ansible.builtin.replace:
+        path: /etc/fstab
+        regexp: '^([^#\n].*\sswap\s.*)$'
+        replace: '# \1'
+
+    - name: Load kernel modules required by RKE2
+      ansible.builtin.command: "modprobe {{ item }}"
+      loop:
+        - overlay
+        - br_netfilter
+      changed_when: false
+
+    - name: Persist required kernel modules across reboots
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/rke2.conf
+        content: |
+          overlay
+          br_netfilter
+        mode: '0644'
+
+    - name: Set sysctl parameters required by RKE2 networking
+      ansible.builtin.copy:
+        dest: /etc/sysctl.d/90-rke2-networking.conf
+        content: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+        mode: '0644'
+      notify: Restart systemd-sysctl

--- a/site.yml
+++ b/site.yml
@@ -1,3 +1,36 @@
 ---
+# Ansible gathers facts (which requires Python) before any role tasks run, so
+# bootstrapping Python on Python-less images (e.g. SLE Micro / immutable
+# transactional-update hosts) has to happen in its own fact-less play, ahead
+# of the main install play.
+- name: Bootstrap Python3 on Python-less hosts
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Check if python3 is already present
+      ansible.builtin.raw: command -v python3 || true
+      register: rke2_python_check
+      changed_when: false
+
+    - name: Detect transactional-update tooling (SUSE MicroOS / SLE Micro)
+      ansible.builtin.raw: command -v transactional-update || true
+      register: rke2_transactional_update_check
+      changed_when: false
+      when: rke2_python_check.stdout | trim == ""
+
+    - name: Install python3 via transactional-update
+      ansible.builtin.raw: transactional-update pkg install -y python3
+      when:
+        - rke2_python_check.stdout | trim == ""
+        - rke2_transactional_update_check.stdout | trim != ""
+      changed_when: true
+      notify: Reboot after python3 bootstrap
+
+  handlers:
+    - name: Reboot after python3 bootstrap
+      ansible.builtin.reboot:
+        reboot_timeout: 600
+
 - name: RKE2 play
   import_playbook: ./playbooks/install.yml


### PR DESCRIPTION
## What type of PR is this?

- [x] feature

## What this PR does / why we need it:

Adds support for deploying RKE2 as a controlplane on SUSE Linux Enterprise Micro 6, which isn't among this role's officially supported/tested platforms (Rocky/RHEL/Ubuntu only).

- **`site.yml`** ([60f3cd8](https://github.com/Doriangaensslen/rke2-ansible/commit/60f3cd81a5f894d3d710f6b42b8bc7fd5477751d)): adds a leading, fact-less bootstrap play that installs Python3 via `transactional-update` on Python-less immutable images before the main install play runs. This has to live at the playbook level rather than inside the role, since Ansible gathers facts (which requires Python) before any role tasks execute — putting it inside the role would already be too late. Reboots automatically if a Python install occurred.
- **`roles/rke2/tasks/pre_reqs.yml`** ([60f3cd8](https://github.com/Doriangaensslen/rke2-ansible/commit/60f3cd81a5f894d3d710f6b42b8bc7fd5477751d)): adds a block scoped to `ansible_facts['os_family'] == 'Suse'` that disables swap, loads/persists the `overlay`/`br_netfilter` kernel modules, and sets the sysctls RKE2 requires. Rocky/RHEL/Ubuntu images already satisfy these; SLE Micro doesn't. Strictly gated to SUSE so behavior for existing users of the role on other platforms is unchanged.


Decisions:
- Reused the role's existing tarball-install path (already auto-selected for any non-RedHat/Rocky OS family) rather than adding zypper/RPM support, since RKE2 doesn't publish a zypper repo.
- Deliberately kept the SUSE additions isolated/gated rather than touching shared install or config logic, to minimize risk to existing Rocky/RHEL/Ubuntu users of this role.
- SLE Micro ships SELinux Enforcing, but the `rke2-selinux` policy package (needed for RKE2's static pods to get a valid SELinux type) is built against RHEL's policy base and isn't available for SUSE. Deploying on an SELinux-enforcing SUSE host currently requires setting `selinux: false` in that inventory's `group_rke2_config`/`cluster_rke2_config` — a deployment-config concern, not something this PR changes in the role itself.

## Which issue(s) this PR fixes:

N/A — no tracked issue.

## Special notes for your reviewer:

- Only validated against SLE Micro 6 as a 3-node, controlplane-only cluster (no `rke2_agents`). Please double-check the `ansible_facts['os_family'] == 'Suse'` gating doesn't affect Rocky/RHEL/Ubuntu behavior.
- The SELinux caveat above is currently just operator knowledge, not enforced/documented anywhere — worth a docs follow-up if this is going to see wider use.

## Testing

- `ansible-lint --profile production` (strictest available profile) and `yamllint`: clean on both changed files.
- `ansible-playbook site.yml --syntax-check`: passes.
- Deployed end-to-end against 3 real SLE Micro 6 hosts as an RKE2 controlplane; all three nodes joined and reached `Ready`.

## Release Notes

```release-note
Add experimental support for installing RKE2 on SUSE Linux Enterprise Micro (SLE Micro), including automatic Python3 bootstrapping on Python-less immutable images and SUSE-specific kernel/sysctl/swap prerequisites.



